### PR TITLE
Fix changeTheme not defined error

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,7 @@
             {% endif %}
         </header>
         <section>
-            <button id="theme-toggle-button" onclick="changeTheme()">
+            <button id="theme-toggle-button">
                 <span id="theme-toggle-icon" class="fa fa-sun-o"></span>
                 <span id="theme-toggle-label">Light Mode</span>
             </button>

--- a/assets/js/enable-dark-mode.js
+++ b/assets/js/enable-dark-mode.js
@@ -22,12 +22,13 @@ document.addEventListener("DOMContentLoaded", function() {
     }
 
     // Function to toggle between dark and light mode
-    window.changeTheme = function() {
+    function changeTheme() {
+        console.log("Button clicked. Toggling theme...");
         if (document.body.classList.contains("dark-mode")) {
             // Switch to light mode
             document.body.classList.remove("dark-mode");
             localStorage.setItem('theme', 'light');
-            themeToggleIcon.className = 'fa fa-sun-o';
+            themeToggleIcon.className = 'fa fa-sun-o'; 
             themeToggleLabel.textContent = 'Light Mode';
         } else {
             // Switch to dark mode
@@ -37,4 +38,7 @@ document.addEventListener("DOMContentLoaded", function() {
             themeToggleLabel.textContent = 'Dark Mode';
         }
     }
+
+    // Bind button to changeTheme function using event listener
+    themeToggleButton.addEventListener("click", changeTheme);
 });


### PR DESCRIPTION
Fix for below error:

`cv/:62 Uncaught ReferenceError: changeTheme is not defined at HTMLButtonElement.onclick (cv/:62:70)`

1. Removes onclick attribute from button. Handles click event entirely in the JavaScript file
2. Defines changeTheme() function before any event handling code