### PR TITLE
Fix broken home link URL

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
 <body>
     <div class="wrapper">
         <header>
-            <h1><a href="{{ " /" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+            <h1><a href="{{ '' | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
 
             {% if site.logo %}
             <img src="{{site.logo | relative_url}}" alt="Logo" />


### PR DESCRIPTION
Home link was routing to:

https://scaulfield7.github.io/cv/%20/

and resulting in a 404 error.

Fixed by removing the code that was appending " /" onto the home route.