### PR TITLE
Update PDF name to match .tex file name

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           root_file: cv.tex
       - name: Test
-        run: cat sarah_caulfield_cv.pdf
+        run: cat cv.pdf
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: sarah_caulfield_cv.pdf
+          files: cv.pdf


### PR DESCRIPTION
Build was failing with the below error:

```
Latexmk: Log file says output to 'cv.pdf'
Latexmk: All targets (cv.pdf) are up-to-date

##[debug]Docker Action run completed with exit code 0
##[debug]Finishing: Compile LaTeX Document
0s
##[debug]Evaluating condition for step: 'Test'
##[debug]Evaluating: success()
##[debug]Evaluating success:
##[debug]=> true
##[debug]Result: true
##[debug]Starting: Test
##[debug]Loading inputs
##[debug]Loading env
Run cat sarah_caulfield_cv.pdf
##[debug]/usr/bin/bash -e /home/runner/work/_temp/cf56326e-44b7-4c31-a535-6860cdf621a4.sh
cat: sarah_caulfield_cv.pdf: No such file or directory
Error: Process completed with exit code 1.
##[debug]Finishing: Test
```

Updated the PDF name to match the file name for the .tex file to resolve this.