### PR TITLE
Replace incorrect . with / in git-auto-commit-action

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           root_file: cv.tex
       - name: Commit PDF
-        uses: stefanzweifel.git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Auto-build CV PDF"
           file_pattern: cv.pdf


### PR DESCRIPTION
Fix for below error:

```[Invalid workflow file: .github/workflows/build-cv.yml#L1](https://github.com/scaulfield7/cv/actions/runs/31836935308/workflow)
(Line: 17, Col: 15): Expected format {org}/{repo}[/path]@ref. Actual 'stefanzweifel.git-auto-commit-action@v5'
```